### PR TITLE
Fix vector error message and add bounds tests

### DIFF
--- a/src/system/native.ts
+++ b/src/system/native.ts
@@ -649,7 +649,7 @@ defun("vector-ref", 2, 2,
 defun("vector-set!", 3, 3,
   function(vector, index, value) {
     if(!(vector instanceof Vector))
-      throw new Error("Can't vector-ref non-vector "+vector);
+      throw new Error("Can't vector-set! non-vector " + vector);
     if(isNaN(index))
       throw new Error("Can't get non-numeric index "+vector);
     if(index < 0 || index >= vector.length())

--- a/src/system/string.ts
+++ b/src/system/string.ts
@@ -21,12 +21,12 @@ export default class String {
     set(i: number, c: Char) {
         if(!(c instanceof Char))
             throw new Error(c+" is not a Char", "String.set")
-        if(i < 0 || i > this._value.length)
+        if(i < 0 || i >= this._value.length)
             throw new Error("Invalid index "+i, "String.set")
         this._value = this._value.slice(0, i)+ c.getValue() +this._value.slice(i+1)
     }
     get(i: number) {
-        if(i < 0 || i > this._value.length)
+        if(i < 0 || i >= this._value.length)
             throw new Error("Invalid index "+i, "String.get")
         
         return this._value[i]

--- a/test/interpreter.js
+++ b/test/interpreter.js
@@ -532,6 +532,8 @@ describe("Strings", function () {
   it('string-set! invalid', function () {
     should_error('(string-set! "" 0 #\\f)')
     should_error('(string-set! "a" 0 "a")')
+    should_error('(string-set! "abc" -1 #\\a)')
+    should_error('(string-set! "abc" 3 #\\a)')
   });
 })
 
@@ -595,6 +597,10 @@ describe("Vectors", function () {
       "(vector-set! v 3 5) " +
       "(vector-ref v 3)))",
       5)
+  });
+  it("vector-set! invalid", function () {
+    should_error("(vector-set! 3 0 1)")
+    should_error("(let ((v (make-vector 2))) (vector-set! v 2 5))")
   });
 })
 


### PR DESCRIPTION
## Summary
- revert accidental package-lock changes
- add bounds tests for `string-set!`
- add error case tests for `vector-set!`

## Testing
- `npm test`
