### PR TITLE
Fix parser indentation handling for strings

### DIFF
--- a/src/system/parser.ts
+++ b/src/system/parser.ts
@@ -45,22 +45,29 @@ export default class Parser {
     let column = 2; // start with 2 to account for prompt
     let leftParensColumns = [];
     for (var i = 0; i < fragment.length; i++) {
-      switch (fragment[i]) {
+      const ch = fragment[i];
+      switch (ch) {
+        case '"':
+          inString = !inString;
+          column++;
+          break;
         case "(":
-          parens++;
-          leftParensColumns.push(column);
+          if (!inString) {
+            parens++;
+            leftParensColumns.push(column);
+          }
           column++;
           break;
         case ")":
-          parens--;
-          leftParensColumns.pop();
+          if (!inString) {
+            parens--;
+            leftParensColumns.pop();
+          }
           column++;
           break;
         case "\n":
           column = 0;
           break;
-        case '"':
-          inString = !inString;
         default:
           column++;
       }

--- a/test/interpreter.js
+++ b/test/interpreter.js
@@ -138,6 +138,11 @@ describe('Parser', function () {
   it("Parse float", function () {
     evto("123456.654321", 123456.654321)
   });
+
+  it("calculateIndentation ignores parens in strings", function() {
+    const indent = FoxScheme.Parser.calculateIndentation('(display "(")');
+    assert_equals(indent, 0);
+  });
 });
 
 /*


### PR DESCRIPTION
## Summary
- avoid counting parentheses inside strings when computing indentation
- test Parser.calculateIndentation for string case

## Testing
- `npm test`