### PR TITLE
Fix escaped quote handling in indentation calculator

### DIFF
--- a/src/system/parser.ts
+++ b/src/system/parser.ts
@@ -47,10 +47,18 @@ export default class Parser {
     for (var i = 0; i < fragment.length; i++) {
       const ch = fragment[i];
       switch (ch) {
-        case '"':
-          inString = !inString;
+        case '"': {
+          // handle escaped quotes inside strings
+          let backslashCount = 0;
+          for (let j = i - 1; j >= 0 && fragment[j] === '\\'; j--) {
+            backslashCount++;
+          }
+          if (backslashCount % 2 === 0) {
+            inString = !inString;
+          }
           column++;
           break;
+        }
         case "(":
           if (!inString) {
             parens++;

--- a/test/interpreter.js
+++ b/test/interpreter.js
@@ -143,6 +143,10 @@ describe('Parser', function () {
     const indent = FoxScheme.Parser.calculateIndentation('(display "(")');
     assert_equals(indent, 0);
   });
+  it("calculateIndentation handles escaped quotes", function() {
+    const indent = FoxScheme.Parser.calculateIndentation('(display "foo \\"(")');
+    assert_equals(indent, 0);
+  });
 });
 
 /*


### PR DESCRIPTION
## Summary
- handle escaped quotes in Parser.calculateIndentation
- add unit test for escaped quotes

## Testing
- `npm test`