### PR TITLE
Add browser REPL example

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>FoxScheme REPL</title>
+  <style>
+    body { font-family: monospace; background: #1e1e1e; color: #e0e0e0; margin: 0; padding: 0; display: flex; flex-direction: column; height: 100vh; }
+    #console { flex: 1; overflow-y: auto; padding: 10px; }
+    .line.input::before { content: '> '; color: #8be9fd; }
+    .line.result { color: #50fa7b; }
+    .line.error { color: #ff5555; }
+    #prompt { border: none; border-top: 1px solid #333; background: #1e1e1e; color: #e0e0e0; padding: 8px; font-family: inherit; font-size: 1em; }
+  </style>
+</head>
+<body>
+  <div id="console"></div>
+  <input id="prompt" autocomplete="off" placeholder="Type Scheme code and press Enter" />
+  <script src="../dist/foxscheme-browser.js"></script>
+  <script src="repl.js"></script>
+</body>
+</html>

--- a/web/repl.js
+++ b/web/repl.js
@@ -1,0 +1,41 @@
+(function() {
+  const consoleDiv = document.getElementById('console');
+  const prompt = document.getElementById('prompt');
+  const interpreter = new FoxScheme.Interpreter();
+  let buffer = '';
+
+  function append(text, cls) {
+    const div = document.createElement('div');
+    div.className = 'line ' + cls;
+    div.textContent = text;
+    consoleDiv.appendChild(div);
+    consoleDiv.scrollTop = consoleDiv.scrollHeight;
+  }
+
+  function evaluate() {
+    try {
+      const parser = new FoxScheme.Parser(buffer);
+      let obj;
+      while((obj = parser.nextObject()) !== FoxScheme.Parser.EOS) {
+        const result = interpreter.eval(obj);
+        append(String(result), 'result');
+      }
+    } catch(err) {
+      append('Error: ' + err.message, 'error');
+    }
+    buffer = '';
+  }
+
+  prompt.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const line = prompt.value;
+      prompt.value = '';
+      buffer += line + '\n';
+      append(line, 'input');
+      if (FoxScheme.Parser.calculateIndentation(buffer) === 0) {
+        evaluate();
+      }
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add `web/index.html` and `web/repl.js` to provide a simple browser REPL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683938eb09408323bd6fdf51b4f8e21c