### PR TITLE
Remove generated parser from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __merged.js
 *.swp
 node_modules
 dist/
+src/system/parser.generated.js

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "webpack",
     "build:types": "tsc --emitDeclarationOnly",
     "build:js": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
+    "build:grammar": "peggy --format commonjs -o src/system/parser.generated.js grammar.peg",
     "test": "mocha -r ts-node/register test/interpreter.js"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- keep `.gitignore` up to date for generated parser
- remove `parser.generated.js` from source control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68392ac393248323a0af556a7ea9a818