### PR TITLE
Add load function for Node

### DIFF
--- a/src/shim/node.ts
+++ b/src/shim/node.ts
@@ -1,7 +1,33 @@
 import repl from 'repl';
+import fs from 'fs';
 import * as FoxScheme from '../foxscheme';
+import {defun} from '../system/native';
+import String from '../system/string';
+import {Error as SchemeError} from '../system/error';
+import nothing from '../system/nothing';
 
 const interp = new FoxScheme.Interpreter();
+
+// Provide a Scheme-level (load) implementation for Node
+defun("load", 1, 2, function(filename, evalproc) {
+  if (!(filename instanceof String))
+    throw new SchemeError("Must specify a filename string to load from", "load");
+  if (evalproc === undefined)
+    evalproc = this.eval;
+  const path = filename.getValue();
+  let data: string;
+  try {
+    data = fs.readFileSync(path, 'utf8');
+  } catch (e) {
+    throw new SchemeError("Failed to read file: " + (e as any).message, "load");
+  }
+  const p = new FoxScheme.Parser(data);
+  let o: any;
+  while ((o = p.nextObject()) !== FoxScheme.Parser.EOS) {
+    evalproc.apply(this, [o]);
+  }
+  return nothing;
+});
 
 let runWithInterpreter: repl.REPLEval;
 runWithInterpreter = function(cmd, context, filename, callback) {
@@ -20,8 +46,12 @@ myWriter = function(obj) {
   return "" + obj;
 }
 
-repl.start({
-  prompt: '> ',
-  eval: runWithInterpreter,
-  writer: myWriter
-})
+if (require.main === module) {
+  repl.start({
+    prompt: '> ',
+    eval: runWithInterpreter,
+    writer: myWriter
+  });
+}
+
+export default FoxScheme;

--- a/test/fixtures/load-test.scm
+++ b/test/fixtures/load-test.scm
@@ -1,0 +1,1 @@
+(define loaded-val 123)

--- a/test/interpreter.js
+++ b/test/interpreter.js
@@ -7,6 +7,9 @@ import 'mocha';
 // このファイルはUTF-8です
 
 import * as $fs from "../src/foxscheme";
+import fs from 'fs';
+import path from 'path';
+import '../src/shim/node';
 let FoxScheme = $fs;
 
 var evto = function (expr, test) {
@@ -987,5 +990,12 @@ describe('Miscellaneous', function () {
       "(fact* (- n 1) (lambda (r) (k (* r n)))))))) " +
       "(fact* 5 (lambda (v) v)))",
       120)
+  });
+});
+
+describe('Node load', function () {
+  it('loads a Scheme file and evaluates its contents', function () {
+    const filename = path.join(__dirname, 'fixtures', 'load-test.scm');
+    evto(`(begin (load "${filename}") loaded-val)`, 123);
   });
 });


### PR DESCRIPTION
## Summary
- add unit test for Node `load`
- implement `load` in Node shim using fs
- ensure Node REPL only starts when run directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e17ec82848323aac3312c237875b8