### PR TITLE
Add comment and ellipsis parsing

### DIFF
--- a/grammar.peg
+++ b/grammar.peg
@@ -18,6 +18,7 @@ Expression
   / Number
   / Character
   / String
+  / Ellipsis
   / Symbol
 
 List
@@ -96,6 +97,9 @@ Character
 CharacterValue
   = val:$[^ \t\n\r()]+ { return val; }
 
+Ellipsis
+  = '...' { return new SymbolObj('...'); }
+
 Symbol
   = !Boolean ident:Identifier { return new SymbolObj(ident); }
 
@@ -110,4 +114,8 @@ Initial
 Subsequent
   = Initial / [0-9] / "." / "+"
 
-_  = [ \t\n\r]*  // optional whitespace
+_  = (Whitespace / LineComment)*
+
+Whitespace = [ \t\n\r]+
+
+LineComment = ';' (![\n\r] .)* ([\n\r] / !.)

--- a/src/system/parser.ts
+++ b/src/system/parser.ts
@@ -16,7 +16,12 @@ export default class Parser {
       this.error = null;
     } catch (e) {
       this.exprs = [];
-      this.error = new Error((e as Error).message);
+      const loc = (e as any).location?.start;
+      if (loc) {
+        this.error = new Error(`${(e as Error).message} at line ${loc.line} column ${loc.column}`);
+      } else {
+        this.error = new Error((e as Error).message);
+      }
     }
     this.i = 0;
   }

--- a/test/interpreter.js
+++ b/test/interpreter.js
@@ -150,6 +150,19 @@ describe('Parser', function () {
     const indent = FoxScheme.Parser.calculateIndentation('(display "foo \\"(")');
     assert_equals(indent, 0);
   });
+
+  it("Ignores semicolon comments", function() {
+    var p = new $fs.Parser("1 ;comment\n2");
+    assert_equals(p.nextObject(), 1);
+    assert_equals(p.nextObject(), 2);
+  });
+
+  it("Parses ellipsis token", function() {
+    var p = new $fs.Parser("...");
+    var o = p.nextObject();
+    assert_instanceof(o, FoxScheme.Symbol);
+    assert_equals(o.name(), "...");
+  });
 });
 
 /*


### PR DESCRIPTION
## Summary
- improve parser errors with line and column numbers
- parse `;` comments
- support the ellipsis token `...`
- test new parser behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e4c780b7483239f40f38bc13ddeff